### PR TITLE
adding flag to enable https for healthcheck urls

### DIFF
--- a/flask_eureka/eurekaclient.py
+++ b/flask_eureka/eurekaclient.py
@@ -70,6 +70,7 @@ class EurekaClient(object):
                  prefer_same_zone=True,
                  context="eureka/v2",
                  eureka_port=None,
+                 https_enabled=False,
                  heartbeat_interval=None,
                  service_path=None):
 
@@ -89,6 +90,7 @@ class EurekaClient(object):
         self.eureka_port = eureka_port
         self.heartbeat_task = None
         self.instance_id = instance_id
+        self.app_protocol = 'https://' if https_enabled else 'http://'
 
         host_info = HostInfo().get()
 
@@ -206,9 +208,9 @@ class EurekaClient(object):
                 'instanceId': self.get_instance_id(),
                 'hostName': self.host_name,
                 'ipAddr': self.vip_address,
-                'healthCheckUrl': 'http://' + self.host_name + ':' + str(self.port) + '/healthcheck',
-                'statusPageUrl': 'http://' + self.host_name + ':' + str(self.port) + '/healthcheck',
-                'homePageUrl': 'http://' + self.host_name + ':' + str(self.port) + '/healthcheck',
+                'healthCheckUrl': self.app_protocol + self.host_name + ':' + str(self.port) + '/healthcheck',
+                'statusPageUrl': self.app_protocol + self.host_name + ':' + str(self.port) + '/healthcheck',
+                'homePageUrl': self.app_protocol + self.host_name + ':' + str(self.port) + '/healthcheck',
                 'port': {
                     '$': self.port,
                     '@enabled': 'true',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+urllib3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests*', 'examples*']),
     include_package_data=True,
-    install_requires=['Flask', 'dnspython'],
+    install_requires=['Flask', 'dnspython', 'urllib3'],
     classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/tests/test_eurekaclient.py
+++ b/tests/test_eurekaclient.py
@@ -1,0 +1,63 @@
+import unittest
+from flask_eureka.eurekaclient import EurekaClient
+
+class EurekaClientMock(unittest.TestCase):
+    def setUp(self):
+        def mock_get_urls(self):
+            pass
+        
+        EurekaClient.get_eureka_urls = mock_get_urls
+        self.mocked_client = EurekaClient
+
+
+
+class TestEurekaClient(EurekaClientMock):
+
+    def test_true_https_flag(self):
+        e_client = self.mocked_client(
+            name='test-eureka-client',
+            host_name='mocked_host_name',
+            port=8080,
+            https_enabled=True
+        )
+        instance_data = e_client.get_instance_data()
+        healthcheckUrl = instance_data['instance']['healthCheckUrl']
+        statusPageUrl = instance_data['instance']['statusPageUrl']
+        homePageUrl = instance_data['instance']['homePageUrl']
+
+        self.assertEqual(healthcheckUrl, 'https://mocked_host_name:8080/healthcheck')
+        self.assertEqual(statusPageUrl, 'https://mocked_host_name:8080/healthcheck')
+        self.assertEqual(homePageUrl, 'https://mocked_host_name:8080/healthcheck')
+
+
+    def test_false_https_flag(self):
+        e_client = self.mocked_client(
+            name='test-eureka-client',
+            host_name='mocked_host_name',
+            port=8080,
+            https_enabled=False
+        )
+        instance_data = e_client.get_instance_data()
+        healthcheckUrl = instance_data['instance']['healthCheckUrl']
+        statusPageUrl = instance_data['instance']['statusPageUrl']
+        homePageUrl = instance_data['instance']['homePageUrl']
+
+        self.assertEqual(healthcheckUrl, 'http://mocked_host_name:8080/healthcheck')
+        self.assertEqual(statusPageUrl, 'http://mocked_host_name:8080/healthcheck')
+        self.assertEqual(homePageUrl, 'http://mocked_host_name:8080/healthcheck')
+
+
+    def test_default_https_flag(self):
+        e_client = self.mocked_client(
+            name='test-eureka-client',
+            host_name='mocked_host_name',
+            port=8080
+        )
+        instance_data = e_client.get_instance_data()
+        healthcheckUrl = instance_data['instance']['healthCheckUrl']
+        statusPageUrl = instance_data['instance']['statusPageUrl']
+        homePageUrl = instance_data['instance']['homePageUrl']
+
+        self.assertEqual(healthcheckUrl, 'http://mocked_host_name:8080/healthcheck')
+        self.assertEqual(statusPageUrl, 'http://mocked_host_name:8080/healthcheck')
+        self.assertEqual(homePageUrl, 'http://mocked_host_name:8080/healthcheck')


### PR DESCRIPTION
The protocol of the healthcheck urls were hardcoded to use http. This change makes it optional to use http or https.