### PR TITLE
Fix IndexOutOfBounds in ipv4 split

### DIFF
--- a/flask_eureka/hostinfo.py
+++ b/flask_eureka/hostinfo.py
@@ -50,7 +50,8 @@ class HostInfo(object):
             ipv4 = getoutput("ifconfig " + self.iface + " | grep 'inet ' | awk '{ print $2 }'")
         else:
             ipv4 = getoutput("ifconfig " + self.iface + " | grep 'inet addr' | awk '{ print $2 }'")
-            ipv4 = ipv4.split(':')[1]
+            if ipv4.__contains__(":"):
+                ipv4 = ipv4.split(':')[1]
 
         # ipv4 = socket.gethostbyname(platform.node())
         # if ipv4.split('.')[0] == '127':


### PR DESCRIPTION
By checking if the string contains ':' this issue could be avoided.
This was done due to the issue #9 I created last year and was a sufficient fix for me. 

Maybe additional unit tests can also improve this class